### PR TITLE
Aligning photos with names and orgs.

### DIFF
--- a/styles/page_styles.css
+++ b/styles/page_styles.css
@@ -1038,6 +1038,7 @@ section
 
 figure {
 	padding: 5px 20px;
+	text-align: center;
 }
 
 .organizer-h3 {


### PR DESCRIPTION
Correcting the horizontal alignment of the photos and the text underneath. The existing style did not account for a larger amount of text. This adjustment fixes that misalignment.

![organizers](https://user-images.githubusercontent.com/1097925/86152167-9f6fb800-bab4-11ea-99b7-243dfeb88101.jpg)
